### PR TITLE
nvim: Add Vim-specific globals to `.luarc.json`

### DIFF
--- a/nvim/.luarc.json
+++ b/nvim/.luarc.json
@@ -1,3 +1,28 @@
 {
-    "runtime.version": "LuaJIT"
+    "$source": "https://github.com/neovim/neovim/blob/master/contrib/luarc.json",
+    "runtime.version": "LuaJIT",
+    "diagnostics": {
+        "enable": true,
+        "globals": [
+            "vim",
+            "describe",
+            "pending",
+            "it",
+            "before_each",
+            "after_each",
+            "setup",
+            "teardown",
+            "lfs"
+        ]
+    },
+    "workspace": {
+        "library": [
+            "runtime/lua",
+            "${3rd}/lfs/library"
+        ],
+        "checkThirdParty": false,
+        "maxPreload": 2000,
+        "preloadFileSize": 1000
+    },
+    "telemetry.enable": false
 }

--- a/nvim/.stylua.toml
+++ b/nvim/.stylua.toml
@@ -1,1 +1,1 @@
-/Users/chrisgrieser/.config/linter-configs/.stylua.toml
+../linter-configs/.stylua.toml


### PR DESCRIPTION
## Changes
* Add globals to `.luarc.json`
    * This ensures that lua-language-server doesn't throw warnings about undefined globals.
    * This helps declutter the error indicator.
* Use relative symlink for StyLua config
    * This ensures portability if other people try out your dotfiles or if you change usernames for whatever reason.
    * I'm not sure how many other symlinks like this are present.